### PR TITLE
Add permanent message on OSD

### DIFF
--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -528,11 +528,16 @@ void AP_Notify::set_flight_mode_str(const char *str)
     _flight_mode_str[sizeof(_flight_mode_str)-1] = 0;
 }
 
-void AP_Notify::send_text(const char *str)
+void AP_Notify::send_text(const char *str, bool permanent)
 {
-    strncpy(_send_text, str, sizeof(_send_text));
-    _send_text[sizeof(_send_text)-1] = 0;
-    _send_text_updated_millis = AP_HAL::millis();
+    if (permanent){
+        strncpy(_permanent_text, str, sizeof(_permanent_text));
+        _permanent_text[sizeof(_permanent_text)-1] = 0;
+    } else {
+        strncpy(_send_text, str, sizeof(_send_text));
+        _send_text[sizeof(_send_text)-1] = 0;
+        _send_text_updated_millis = AP_HAL::millis();
+    }
 }
 
 #if AP_SCRIPTING_ENABLED

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -207,8 +207,8 @@ public:
     const char* get_flight_mode_str() const { return _flight_mode_str; }
 
     // send text to display
-    void send_text(const char *str);
-    const char* get_text() const { return _send_text; }
+    void send_text(const char *str, bool permanent = false);
+    const char* get_text(bool permanent = false) const { return permanent? _permanent_text :_send_text; }
     uint32_t get_text_updated_millis() const {return _send_text_updated_millis; }
  
 #if AP_SCRIPTING_ENABLED
@@ -251,6 +251,7 @@ private:
     AP_Int8 _led_len;
 
     char _send_text[NOTIFY_TEXT_BUFFER_SIZE];
+    char _permanent_text[NOTIFY_TEXT_BUFFER_SIZE];
     uint32_t _send_text_updated_millis; // last time text changed
     char _flight_mode_str[5];
 

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -186,6 +186,7 @@ private:
     AP_OSD_Setting sats{true, 1, 3};
     AP_OSD_Setting fltmode{true, 2, 8};
     AP_OSD_Setting message{true, 2, 6};
+    AP_OSD_Setting message_permanent{true, 2, 5};
     AP_OSD_Setting gspeed{true, 2, 14};
     AP_OSD_Setting horizon{true, 14, 8};
     AP_OSD_Setting home{true, 14, 1};
@@ -275,6 +276,7 @@ private:
     void draw_sats(uint8_t x, uint8_t y);
     void draw_fltmode(uint8_t x, uint8_t y);
     void draw_message(uint8_t x, uint8_t y);
+    void draw_message_permanent(uint8_t x, uint8_t y);
     void draw_gspeed(uint8_t x, uint8_t y);
     void draw_horizon(uint8_t x, uint8_t y);
     void draw_home(uint8_t x, uint8_t y);
@@ -296,6 +298,7 @@ private:
     void draw_pluscode(uint8_t x, uint8_t y);
 #endif
     //helper functions
+    void draw_buffer(uint8_t x, uint8_t y, const char *input_buffer, int32_t visible_time);
     void draw_speed(uint8_t x, uint8_t y, float angle_rad, float magnitude);
     void draw_distance(uint8_t x, uint8_t y, float distance);
     char get_arrow_font_index (int32_t angle_cd);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2354,7 +2354,7 @@ void GCS::send_textv(MAV_SEVERITY severity, const char *fmt, va_list arg_list, u
 #endif
     AP_Notify *notify = AP_Notify::get_singleton();
     if (notify) {
-        notify->send_text(first_piece_of_text);
+        notify->send_text(first_piece_of_text, severity == MAV_SEVERITY_ENUM_END);
     }
 
     // push the messages out straight away until the vehicle states
@@ -3520,8 +3520,9 @@ void GCS_MAVLINK::handle_statustext(const mavlink_message_t &msg) const
     }
 
     memcpy(&text[offset], packet.text, MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN);
+    bool use_prefix = packet.severity != MAV_SEVERITY_ENUM_END;
 
-    send_text(MAV_SEVERITY_INFO, "%s", text);
+    send_text((MAV_SEVERITY)packet.severity, "%s", text + (use_prefix? 0: offset));
 
     logger->Write_Message(text);
 #endif


### PR DESCRIPTION
Using `MAV_SEVERITY_ENUM_END` mavlink `statustext` command a permantent message can be displayed on the OSD