### PR TITLE
Extend SIMSTATE

### DIFF
--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -1249,6 +1249,12 @@ void SIM::simstate_send(mavlink_channel_t chan) const
         yaw -= 360;
     }
 
+    const float alt_msl = state.altitude;
+    float relative_alt = alt_msl;
+    if (!state.home.is_zero()) {
+        relative_alt -= float(state.home.alt) * 0.01f;
+    }
+
     mavlink_msg_simstate_send(chan,
                               ToRad(state.rollDeg),
                               ToRad(state.pitchDeg),
@@ -1260,7 +1266,9 @@ void SIM::simstate_send(mavlink_channel_t chan) const
                               radians(state.pitchRate),
                               radians(state.yawRate),
                               state.latitude*1.0e7,
-                              state.longitude*1.0e7);
+                              state.longitude*1.0e7,
+                              alt_msl,
+                              relative_alt);
 }
 
 /* report SITL state via MAVLink SIM_STATE */


### PR DESCRIPTION
I have confirmed that now `ardupilot` sends those fields:
```
GUIDED_NOGPS> 4369: SIMSTATE {roll : -0.0019512837752699852, pitch : -0.0018649451667442918, yaw : 0.017762046307325363, xacc : 0.18761742115020752, yacc : 0.3926701247692108, zacc : -9.814364433288574, xgyro : -0.001485959510318935, ygyro : -0.00033868401078507304, zgyro : 0.00876267347484827, lat : 510360073, lng : 1708026, alt : 189.08999633789062, relative_alt : 50.089996337890625}
```
(the drone was told to fly to 50m altitude)


But the way to confirm this yourself will be in the next PR, as it requires some changes in mavproxy that aren't yet merged, heh. So I guess, just trust me that it works.